### PR TITLE
add units and standard_name

### DIFF
--- a/yaml/draft_yaml/voto_variables.yaml
+++ b/yaml/draft_yaml/voto_variables.yaml
@@ -1,6 +1,8 @@
 AD2CP_HEADING:
   comment: measured by AD2CP
   long_name: Orientation (horizontal relative to magnetic north) of measurement platform {heading}
+  standard_name: platform_orientation
+  units: Degrees
   vocabulary: http://vocab.nerc.ac.uk/collection/OG1/current/HEADING/
 AD2CP_PITCH:
   comment: measured by AD2CP

--- a/yaml/validated_yaml/og1_variables.yaml
+++ b/yaml/validated_yaml/og1_variables.yaml
@@ -1,3 +1,12 @@
+AD2CP_HEADING:
+  _FillValue: NaNf
+  comment: measured by AD2CP
+  coordinates: TIME, LONGITUDE, LATITUDE, DEPTH
+  long_name: Orientation (horizontal relative to magnetic north) of measurement platform
+    {heading}
+  standard_name: platform_orientation
+  units: Degrees
+  vocabulary: http://vocab.nerc.ac.uk/collection/OG1/current/HEADING/
 AD2CP_TIME:
   _FillValue: NaNf
   axis: T


### PR DESCRIPTION
This is an example PR.

I run the script `og1_variables.py` to read in variables yaml from `yaml/draft_yaml`. I note from the log output that the first input term "AD2CP_HEADING" is failing with an error message:

```
2025-12-01 16:43:34 ERROR    expected keys {'units', 'standard_name'} not found in AD2CP_HEADING
```

So, I add units (taken from the related term P06 of the OG1 NVS entry for HEADING http://vocab.nerc.ac.uk/collection/OG1/current/HEADING/) and the standard name platform_orientation from the CF standard names table https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html

I re-run the script, and now this term is approved and is output to `yaml/validated_yaml/og1_variables.yaml`