### PR TITLE
correct wetlabs puck model and remove SB43

### DIFF
--- a/yaml/draft_yaml/voto_sensors.yaml
+++ b/yaml/draft_yaml/voto_sensors.yaml
@@ -78,14 +78,6 @@ Satlantic {Sea-Bird} Submersible Ultraviolet Nitrate Analyser V2 (SUNA V2) nutri
   sensor_model_vocabulary: http://vocab.nerc.ac.uk/collection/L22/current/TOOL1562/
   sensor_type: nutrient analysers
   sensor_type_vocabulary: http://vocab.nerc.ac.uk/collection/L05/current/181/
-Sea-Bird SBE 43F Dissolved Oxygen Sensor:
-  long_name: Sea-Bird SBE 43F
-  sensor_maker: Sea-Bird Scientific
-  sensor_maker_vocabulary: http://vocab.nerc.ac.uk/collection/L35/current/MAN0013/
-  sensor_model: Sea-Bird SBE 43F Dissolved Oxygen Sensor
-  sensor_model_vocabulary: http://vocab.nerc.ac.uk/collection/L22/current/TOOL0037/
-  sensor_type: dissolved gas sensors
-  sensor_type_vocabulary: http://vocab.nerc.ac.uk/collection/L05/current/351/
 Sea-Bird Slocum Glider Payload {GPCTD} CTD:
   long_name: Sea-Bird Slocum CTD
   sensor_maker: Sea-Bird Scientific
@@ -118,12 +110,12 @@ WET Labs {Sea-Bird WETLabs} ECO Puck Triplet FLBBPC scattering fluorescence sens
   sensor_model_vocabulary: http://vocab.nerc.ac.uk/collection/L22/current/TOOL1904/
   sensor_type: fluorometers
   sensor_type_vocabulary: http://vocab.nerc.ac.uk/collection/L05/current/113/
-WET Labs {Sea-Bird WETLabs} ECO Triplet sensor:
+WET Labs {Sea-Bird WETLabs} ECO Puck Triplet sensor:
   long_name: WET Labs ECO-FLBBCE
   sensor_maker: WET Labs
   sensor_maker_vocabulary: http://vocab.nerc.ac.uk/collection/L35/current/MAN0026/
-  sensor_model: WET Labs {Sea-Bird WETLabs} ECO Triplet sensor
-  sensor_model_vocabulary: http://vocab.nerc.ac.uk/collection/L22/current/TOOL0674/
+  sensor_model: WET Labs {Sea-Bird WETLabs} ECO Puck Triplet sensor
+  sensor_model_vocabulary: http://vocab.nerc.ac.uk/collection/L22/current/TOOL0673/
   sensor_type: fluorometers
   sensor_type_vocabulary: http://vocab.nerc.ac.uk/collection/L05/current/113/
 WET Labs {Sea-Bird WETLabs} SeaOWL UV-A Sea Oil-in-Water Locator:

--- a/yaml/validated_yaml/og1_sensors.yaml
+++ b/yaml/validated_yaml/og1_sensors.yaml
@@ -80,14 +80,6 @@ Satlantic {Sea-Bird} Submersible Ultraviolet Nitrate Analyser V2 (SUNA V2) nutri
   sensor_model_vocabulary: http://vocab.nerc.ac.uk/collection/L22/current/TOOL1562/
   sensor_type: nutrient analysers
   sensor_type_vocabulary: http://vocab.nerc.ac.uk/collection/L05/current/181/
-Sea-Bird SBE 43F Dissolved Oxygen Sensor:
-  long_name: Sea-Bird SBE 43F Dissolved Oxygen Sensor
-  sensor_maker: Sea-Bird Scientific
-  sensor_maker_vocabulary: http://vocab.nerc.ac.uk/collection/L35/current/MAN0013/
-  sensor_model: Sea-Bird SBE 43F Dissolved Oxygen Sensor
-  sensor_model_vocabulary: http://vocab.nerc.ac.uk/collection/L22/current/TOOL0037/
-  sensor_type: dissolved gas sensors
-  sensor_type_vocabulary: http://vocab.nerc.ac.uk/collection/L05/current/351/
 Sea-Bird Slocum Glider Payload {GPCTD} CTD:
   long_name: Sea-Bird Slocum Glider Payload {GPCTD} CTD
   sensor_maker: Sea-Bird Scientific
@@ -124,12 +116,12 @@ WET Labs {Sea-Bird WETLabs} ECO Puck Triplet FLBBPC scattering fluorescence sens
   sensor_model_vocabulary: http://vocab.nerc.ac.uk/collection/L22/current/TOOL1904/
   sensor_type: fluorometers
   sensor_type_vocabulary: http://vocab.nerc.ac.uk/collection/L05/current/113/
-WET Labs {Sea-Bird WETLabs} ECO Triplet sensor:
-  long_name: WET Labs {Sea-Bird WETLabs} ECO Triplet sensor
+WET Labs {Sea-Bird WETLabs} ECO Puck Triplet sensor:
+  long_name: WET Labs {Sea-Bird WETLabs} ECO Puck Triplet sensor
   sensor_maker: WET Labs
   sensor_maker_vocabulary: http://vocab.nerc.ac.uk/collection/L35/current/MAN0026/
-  sensor_model: WET Labs {Sea-Bird WETLabs} ECO Triplet sensor
-  sensor_model_vocabulary: http://vocab.nerc.ac.uk/collection/L22/current/TOOL0674/
+  sensor_model: WET Labs {Sea-Bird WETLabs} ECO Puck Triplet sensor
+  sensor_model_vocabulary: http://vocab.nerc.ac.uk/collection/L22/current/TOOL0673/
   sensor_type: fluorometers
   sensor_type_vocabulary: http://vocab.nerc.ac.uk/collection/L05/current/113/
 WET Labs {Sea-Bird WETLabs} SeaOWL UV-A Sea Oil-in-Water Locator:


### PR DESCRIPTION
We use the Puck, not the full size ECO sensor. And we do not put an SBER 43F on gliders