### PR TITLE
Change units from 1e-3 to 1 in voto_variables.yaml

### DIFF
--- a/yaml/draft_yaml/voto_variables.yaml
+++ b/yaml/draft_yaml/voto_variables.yaml
@@ -145,7 +145,7 @@ PSAL:
   observation_type: calculated
   sources: CNDC, TEMP, PRES
   standard_name: sea_water_practical_salinity
-  units: 1e-3
+  units: 1
   valid_max: 40
   valid_min: 0
   vocabulary: http://vocab.nerc.ac.uk/collection/OG1/current/PSAL/


### PR DESCRIPTION
Following the discussion over on OG1, this should have units '1' https://github.com/OceanGlidersCommunity/OG-format-user-manual/issues/285